### PR TITLE
Fix BMP file access

### DIFF
--- a/NeoGB_Printer/WiFi_Server.ino
+++ b/NeoGB_Printer/WiFi_Server.ino
@@ -97,11 +97,14 @@ void refreshWebData(){
         #ifdef PNG_OUTPUT
           sprintf(imgDir, "/output/png/%s.png", imgName);
           if(FSYS.exists(imgDir)){
-            file.print(",\"png\":1}");
+            file.print(",\"png\":1");
           }else{
-            file.print(",\"png\":0}");
+            file.print(",\"png\":0");
           }
         #endif
+
+        file.print("}");
+
         imgFile = root.openNextFile();
       }
     }


### PR DESCRIPTION
Fixed missing closing bracket in generated ImgList.json if BMP output is
used