### PR TITLE
Handle power loss during conversion

### DIFF
--- a/NeoGB_Printer/includes/StoreIDlib.h
+++ b/NeoGB_Printer/includes/StoreIDlib.h
@@ -153,6 +153,20 @@ unsigned long update_get_dumps(int mod) {
   file.close();
   return dumps;
 }
+void set_dumps(long dumps) {
+  uint8_t buf[8];
+  char path[]="/ID_storage.bin";
+  File file = FSYS.open(path);
+  file.read(buf, 8);
+  file.close();
+  buf[7] = dumps >>  0;
+  buf[6] = dumps >>  8;
+  buf[5] = dumps >> 16;
+  buf[4] = dumps >> 24;
+  file = FSYS.open(path,FILE_WRITE);
+  file.write(buf, 8);
+  file.close();
+}
 /////////////////////////////////////////////////////////////////////////////////////update the dumps////////////////
 
 /////////////////////////////////////////////////////////////////////////////////////update the total images////////////////


### PR DESCRIPTION
I accidentally hit reset while converting files, and it happened after the dump files were already deleted, but before the final file was written out. As result, the dump counter never got decremented, and it would always show that there is one dump to be converted.

This PR reduces the likelihood that dumps will be irrecoverably lost in case of power loss or reset during conversion:

- Only delete the dumps after all the conversion is done.
- In case the dump files get deleted before the dump counter is decremented, the counter would be out of sync with the actual number of files under /dumps. If that happens, set the dumps count to 0 after all the files have been processed.